### PR TITLE
fix: cover the large viewport in the theme toggle reveal on mobile

### DIFF
--- a/app/components/darkmode.vue
+++ b/app/components/darkmode.vue
@@ -22,14 +22,18 @@ function onToggle(event: MouseEvent) {
     return;
   }
 
+  const root = document.documentElement;
   const rect = button.value?.getBoundingClientRect();
-  const x = event.clientX || (rect ? rect.left + rect.width / 2 : window.innerWidth / 2);
+  const x = event.clientX || (rect ? rect.left + rect.width / 2 : root.clientWidth / 2);
   const y = event.clientY || (rect ? rect.top + rect.height / 2 : 0);
 
-  const radius = Math.hypot(
-    Math.max(x, window.innerWidth - x),
-    Math.max(y, window.innerHeight - y),
-  );
+  // The snapshot is sized to the large viewport — mobile chrome retracted — so
+  // innerHeight under-measures it while the URL bar is showing and the circle
+  // stops short of the bottom of the screen. clientHeight tracks the layout
+  // viewport; the margin absorbs what's left. Over-covering is invisible.
+  const vw = Math.max(window.innerWidth, root.clientWidth);
+  const vh = Math.max(window.innerHeight, root.clientHeight);
+  const radius = Math.hypot(Math.max(x, vw - x), Math.max(y, vh - y)) + 120;
 
   const collapse = !isDark.value;
   const covering = `circle(${radius}px at ${x}px ${y}px)`;


### PR DESCRIPTION
The circular reveal measured its radius with window.innerHeight, which on a phone is the small viewport — it shrinks while the URL bar is showing. The view-transition snapshot is sized to the large viewport instead, with the browser chrome retracted, so the circle was measured against a shorter box than the one it had to fill and stopped short of the bottom of the screen. The strip behind the URL bar never got revealed and the theme snapped in at the end of the animation instead of sweeping across.

Measure against max(innerWidth, documentElement.clientWidth) and max(innerHeight, documentElement.clientHeight) — clientHeight tracks the layout viewport, which is the large one — plus a 120px margin to absorb any remaining inset. Over-covering is invisible; under-covering was the bug.

The circle's origin needs no adjustment: clientX/clientY are already relative to the layout viewport, the same coordinate space the snapshot uses.

Desktop was unaffected (there innerHeight is the viewport), and emulated mobile did not reproduce it either, since a fixed 375x812 viewport has no retractable chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark mode transition coverage to ensure the animation fully encompasses the viewport.
  * Corrected transition positioning across varying page and window dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->